### PR TITLE
Module branch

### DIFF
--- a/lib/item.rb
+++ b/lib/item.rb
@@ -2,7 +2,8 @@ require 'pry'
 require 'bigdecimal'
 
 class Item
-  attr_reader :id, :name, :description, :unit_price, :created_at, :updated_at, :merchant_id
+  attr_reader :id, :created_at, :updated_at, :merchant_id
+  attr_accessor :name, :description, :unit_price
 
   def initialize(item_info)
     @id = item_info[:id]

--- a/lib/itemrepository.rb
+++ b/lib/itemrepository.rb
@@ -1,0 +1,5 @@
+class ItemRepository
+  def initialize(all = [])
+    @all = all
+  end
+end

--- a/lib/itemrepository.rb
+++ b/lib/itemrepository.rb
@@ -1,4 +1,10 @@
+require_relative 'reposable'
+
 class ItemRepository
+  include Reposable
+
+  attr_reader :all
+
   def initialize(all = [])
     @all = all
   end

--- a/lib/reposable.rb
+++ b/lib/reposable.rb
@@ -25,4 +25,8 @@ module Reposable
       end
     end
   end
+
+  def delete(id)
+    all.delete(find_by_id(id))
+  end
 end

--- a/lib/reposable.rb
+++ b/lib/reposable.rb
@@ -6,4 +6,18 @@ module Reposable
   def create(attributes)
     all << class_name.new(attributes)
   end
+  
+  def find_by_id(id)
+    all.find do |entry|
+      entry.id == id
+    end
+  end
+
+
+#   def update(id,attributes)
+#     attributes.each do |attr,val|
+#       find_by_id
+# require 'pry'; binding.pry
+#     end
+  
 end

--- a/lib/reposable.rb
+++ b/lib/reposable.rb
@@ -2,4 +2,8 @@ module Reposable
   def class_name
     Object.const_get(self.class.name.chomp('Repository'))
   end
+
+  def create(attributes)
+    all << class_name.new(attributes)
+  end
 end

--- a/lib/reposable.rb
+++ b/lib/reposable.rb
@@ -13,11 +13,16 @@ module Reposable
     end
   end
 
-
-#   def update(id,attributes)
-#     attributes.each do |attr,val|
-#       find_by_id
-# require 'pry'; binding.pry
-#     end
-  
+  def update(id,attributes)
+    attributes.each do |att,val|
+      case att
+      when :name
+        find_by_id(id).name = val
+      when :description
+        find_by_id(id).description = val
+      when :unit_price
+        find_by_id(id).unit_price = val
+      end
+    end
+  end
 end

--- a/lib/reposable.rb
+++ b/lib/reposable.rb
@@ -1,0 +1,5 @@
+module Reposable
+  def class_name
+    Object.const_get(self.class.name.chomp('Repository'))
+  end
+end

--- a/spec/itemrepository_spec.rb
+++ b/spec/itemrepository_spec.rb
@@ -1,0 +1,10 @@
+require './lib/itemrepository'
+require './lib/item'
+
+RSpec.describe ItemRepository do
+  let(:item_repository) {ItemRepository.new}
+
+  it 'is an instance of ItemRepository' do
+    expect(item_repository).to be_a ItemRepository
+  end
+end

--- a/spec/itemrepository_spec.rb
+++ b/spec/itemrepository_spec.rb
@@ -4,7 +4,7 @@ require './lib/item'
 RSpec.describe ItemRepository do
   let(:item_repository) {ItemRepository.new}
 
-  it 'is an instance of ItemRepository' do
+  it 'exists' do
     expect(item_repository).to be_a ItemRepository
   end
 end

--- a/spec/reposable_spec.rb
+++ b/spec/reposable_spec.rb
@@ -1,0 +1,11 @@
+require './lib/reposable'
+require './lib/itemrepository'
+
+RSpec.describe Reposable do
+  describe '#class_name' do
+    it 'returns the name of the class the current repo is storing' do
+      item_repo = ItemRepository.new
+      expect(item_repo.class_name).to eq Item
+    end
+  end
+end

--- a/spec/reposable_spec.rb
+++ b/spec/reposable_spec.rb
@@ -1,10 +1,13 @@
 require './lib/reposable'
 require './lib/itemrepository'
+require './lib/item'
 
 RSpec.describe Reposable do
   describe '#class_name' do
-    it 'returns the name of the class the current repo is storing' do
+    it 'returns a const of the class the current repo is storing' do
+      item = Item.new({})  
       item_repo = ItemRepository.new
+
       expect(item_repo.class_name).to eq Item
     end
   end

--- a/spec/reposable_spec.rb
+++ b/spec/reposable_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Reposable do
   end
 
   describe '#create' do
-    it 'adds a new instance of the class corresponding to the current repo' do
+    it 'adds a new instance corresponding to the current repo' do
       item_repo = ItemRepository.new
       item_repo.create({
         :id          => 1,
@@ -26,6 +26,30 @@ RSpec.describe Reposable do
       })
 
       expect(item_repo.all[0]).to be_a Item
+    end
+  end
+
+  describe '#update' do
+    it 'updates an instance with the corresponding id' do
+      item_repo = ItemRepository.new
+      item_repo.create({
+        :id          => 1,
+        :name        => "Pencil",
+        :description => "You can use it to write things",
+        :unit_price  => BigDecimal(10.99,4),
+        :created_at  => Time.now,
+        :updated_at  => Time.now,
+        :merchant_id => 2
+      })
+      item_repo.update({
+        :name        => "Broken Pencil",
+        :description => "You now have a smaller pencil",
+        :unit_price  => BigDecimal(5.99,4)
+      })
+
+      expect(item_repo.all[0].name).to eq "Broken Pencil"
+      expect(item_repo.all[0].description).to eq "You now have a smaller pencil"
+      expect(item_repo.all[0].unit_price).to eq BigDecimal(5.99,4)
     end
   end
 end

--- a/spec/reposable_spec.rb
+++ b/spec/reposable_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Reposable do
         :updated_at  => Time.now,
         :merchant_id => 2
       })
-      item_repo.update({
+      item_repo.update(1, {
         :name        => "Broken Pencil",
         :description => "You now have a smaller pencil",
         :unit_price  => BigDecimal(5.99,4)
@@ -50,6 +50,23 @@ RSpec.describe Reposable do
       expect(item_repo.all[0].name).to eq "Broken Pencil"
       expect(item_repo.all[0].description).to eq "You now have a smaller pencil"
       expect(item_repo.all[0].unit_price).to eq BigDecimal(5.99,4)
+    end
+  end
+
+  describe '#find_by_id' do
+    it 'returns either nil or an instance with matching id' do
+      item = Item.new({
+        :id          => 1,
+        :name        => "Pencil",
+        :description => "You can use it to write things",
+        :unit_price  => BigDecimal(10.99,4),
+        :created_at  => Time.now,
+        :updated_at  => Time.now,
+        :merchant_id => 2
+      })  
+      item_repo = ItemRepository.new([item])
+
+      expect(item_repo.find_by_id(1)).to eq item
     end
   end
 end

--- a/spec/reposable_spec.rb
+++ b/spec/reposable_spec.rb
@@ -69,4 +69,25 @@ RSpec.describe Reposable do
       expect(item_repo.find_by_id(1)).to eq item
     end
   end
+
+  describe '#delete' do
+    it 'deletes instance with corresponding id' do
+      item = Item.new({
+        :id          => 1,
+        :name        => "Pencil",
+        :description => "You can use it to write things",
+        :unit_price  => BigDecimal(10.99,4),
+        :created_at  => Time.now,
+        :updated_at  => Time.now,
+        :merchant_id => 2
+      })  
+      item_repo = ItemRepository.new([item])
+
+      expect(item_repo.all).to eq [item]
+      
+      item_repo.delete(1)
+
+      expect(item_repo.all).to eq []
+    end
+  end
 end

--- a/spec/reposable_spec.rb
+++ b/spec/reposable_spec.rb
@@ -11,4 +11,21 @@ RSpec.describe Reposable do
       expect(item_repo.class_name).to eq Item
     end
   end
+
+  describe '#create' do
+    it 'adds a new instance of the class corresponding to the current repo' do
+      item_repo = ItemRepository.new
+      item_repo.create({
+        :id          => 1,
+        :name        => "Pencil",
+        :description => "You can use it to write things",
+        :unit_price  => BigDecimal(10.99,4),
+        :created_at  => Time.now,
+        :updated_at  => Time.now,
+        :merchant_id => 2
+      })
+
+      expect(item_repo.all[0]).to be_a Item
+    end
+  end
 end


### PR DESCRIPTION
I wasn't able to work much specifically on ItemRepository (it's getting late now), but I was able to set up a module called Reposable with `find_by_id`, `create`, `update`, and `delete` methods that should work for all future Repository classes.  I also think it's probably best to have every repository's array be called `all` since every repository already calls for that as a method, and having them named internally the same thing is the only way to get a module working across all of them (I think).